### PR TITLE
Recommend using version 1.0.0 of the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Make sure the following is present in your `composer.json` file:
 ```json
 {
     "require": {
-        "camspiers/json-pretty": "0.1.*"
+        "camspiers/json-pretty": "1.0.*"
     }
 }
 ```


### PR DESCRIPTION
If 1.0.0 is not quite ready for production yet, feel free to close this. I just thought it'd be nice to have the latest version in the readme.
