### PR TITLE
Allow is_json to be defined to skip slow isJson() call

### DIFF
--- a/src/Camspiers/JsonPretty/JsonPretty.php
+++ b/src/Camspiers/JsonPretty/JsonPretty.php
@@ -9,14 +9,19 @@ class JsonPretty
      * process, else it encodes the input as json then
      * runs prettify.
      *
-     * @param  mixed  $json   The json string or object to prettify
-     * @param  int    $flags  The flags to use in json encoding
-     * @param  string $indent The indentation character string
+     * @param  mixed  $json             The json string or object to prettify
+     * @param  int    $flags            The flags to use in json encoding
+     * @param  string $indent           The indentation character string
+     * @param  bool   $is_json          Is the input already in JSON format?
      * @return string The prettified json
      */
-    public function prettify($json, $flags = null, $indent = "\t")
+    public function prettify($json, $flags = null, $indent = "\t", $is_json=null)
     {
-        if (!$this->isJson($json)) {
+        if (!isset($is_json)) {
+            $is_json = $this->isJson($json);
+        }
+
+        if (!$is_json) {
             return $this->process(json_encode($json, $flags), $indent);
         }
 

--- a/tests/Camspiers/JsonPretty/JsonPrettyTest.php
+++ b/tests/Camspiers/JsonPretty/JsonPrettyTest.php
@@ -24,6 +24,8 @@ class JsonPrettyTest extends \PHPUnit_Framework_TestCase
 \t}
 }
 JSON
+                ,
+                false
             ),
 
             // PrettifyWithEscapedSlashBeforeStringEnd
@@ -40,6 +42,8 @@ JSON
 \t"bar": "baz"
 }
 JSON
+                ,
+                false
             ),
 
             // https://github.com/camspiers/json-pretty/issues/9
@@ -100,6 +104,76 @@ JSON
 \t}
 ]
 JSON
+                ,
+                false
+            ),
+
+            // Default test case with JSON input
+            array(
+                '{"test":"test","object":{"hello":"hello"}}'
+                ,
+<<<JSON
+{
+\t"test": "test",
+\t"object": {
+\t\t"hello": "hello"
+\t}
+}
+JSON
+                ,
+                true
+            ),
+
+            // PrettifyWithEscapedSlashBeforeStringEnd with JSON input
+            array(
+                '{"test":"test","foo":"alice\\\bob\\\","bar":"baz"}'
+            ,
+<<<JSON
+{
+\t"test": "test",
+\t"foo": "alice\\\bob\\\",
+\t"bar": "baz"
+}
+JSON
+                ,
+                true
+            ),
+
+            // https://github.com/camspiers/json-pretty/issues/9 JSON input
+            array(
+                '[{"id":"34","system_id":"2000","src":"***","dst":"790","dcontext":"RingGroups-2000","clid":"***","channel":"SIP\/***-0000005c","dstchannel":"SIP\/2000200-0000005d","lastapp":"Dial","lastdata":"SIP\/2000200&SIP\/2000201),20,ktwx","calldate":"2015-09-08 08:56:10","answer":"2015-09-08 08:56:10","end":"2015-09-08 08:56:20","duration":"10","billsec":"0","disposition":"NO ANSWER","uniqueid":"pbx1-1441698970.92","linkedid":"pbx1-1441698970.92","internal":"0","outbound":"0","inbound":"1","uploaded":"0","ddi":null}]'
+                ,
+<<<JSON
+[
+\t{
+\t\t"id": "34",
+\t\t"system_id": "2000",
+\t\t"src": "***",
+\t\t"dst": "790",
+\t\t"dcontext": "RingGroups-2000",
+\t\t"clid": "***",
+\t\t"channel": "SIP\/***-0000005c",
+\t\t"dstchannel": "SIP\/2000200-0000005d",
+\t\t"lastapp": "Dial",
+\t\t"lastdata": "SIP\/2000200&SIP\/2000201),20,ktwx",
+\t\t"calldate": "2015-09-08 08:56:10",
+\t\t"answer": "2015-09-08 08:56:10",
+\t\t"end": "2015-09-08 08:56:20",
+\t\t"duration": "10",
+\t\t"billsec": "0",
+\t\t"disposition": "NO ANSWER",
+\t\t"uniqueid": "pbx1-1441698970.92",
+\t\t"linkedid": "pbx1-1441698970.92",
+\t\t"internal": "0",
+\t\t"outbound": "0",
+\t\t"inbound": "1",
+\t\t"uploaded": "0",
+\t\t"ddi": null
+\t}
+]
+JSON
+                ,
+                true
             ),
 
         );
@@ -108,16 +182,31 @@ JSON
     /**
      * @dataProvider dataPrettify
      */
-    public function testPrettify($object, $expected)
+    public function testPrettify($object, $expected, $is_json)
     {
         $jsonPretty = new JsonPretty;
         $this->assertEquals(
             $expected,
             $jsonPretty->prettify($object)
         );
+
+        if (!$is_json) {
+            $this->assertEquals(
+                $expected,
+                $jsonPretty->prettify(json_encode($object))
+            );
+        }
+    }
+
+    /**
+     * @dataProvider dataPrettify
+     */
+    public function testPrettifyIsJsonOverride($object, $expected, $is_json)
+    {
+        $jsonPretty = new JsonPretty;
         $this->assertEquals(
             $expected,
-            $jsonPretty->prettify(json_encode($object))
+            $jsonPretty->prettify($object, null, "\t", $is_json)
         );
     }
 }


### PR DESCRIPTION
The isJson() call takes up about >99% of runtime. I have added $is_json as an input parameter to allow the call to be skipped if you know the input format.

I used this script to profile it:

``` php
for ($i=0; $i<1000; $i++) {
        for ($j=0; $j<100; $j++) {
                $arr[$i][uniqid()] = uniqid();
        }
}

$start_time = microtime(true);
$jsonPretty = new Camspiers\JsonPretty\JsonPretty;
$converted  = $jsonPretty->prettify($arr); // pass in $is_json parameter for second run
echo (microtime(true) - $start_time)."\n";
```

Before:

```
0.88120579719543
```

After:

```
0.00054192543029785
```

As you can see, this led to a speed up of almost 2000x.
