### PR TITLE
$flags should default to 0

### DIFF
--- a/src/Camspiers/JsonPretty/JsonPretty.php
+++ b/src/Camspiers/JsonPretty/JsonPretty.php
@@ -15,7 +15,7 @@ class JsonPretty
      * @param  bool   $is_json          Is the input already in JSON format?
      * @return string The prettified json
      */
-    public function prettify($json, $flags = null, $indent = "\t", $is_json=null)
+    public function prettify($json, $flags = 0, $indent = "\t", $is_json=null)
     {
         if (!isset($is_json)) {
             $is_json = $this->isJson($json);


### PR DESCRIPTION
$flags should default to 0 per

<img width="661" alt="image" src="https://user-images.githubusercontent.com/133747/164134913-19b2581d-b396-4aaf-8601-dca84ac47eb3.png">

This is throwing in PHP8

```
json_encode(): Passing null to parameter #2 ($flags) of type int is deprecated
```